### PR TITLE
Add explicit import of get_ipython()

### DIFF
--- a/igv_notebook/file_reader.py
+++ b/igv_notebook/file_reader.py
@@ -1,4 +1,5 @@
 import base64
+from IPython import get_ipython
 
 try:
     import google.colab.output


### PR DESCRIPTION
As is, the code works if run directly inside a Jupyter notebook. It works because get_ipython() has already been implicitly imported into the top-level namespace. However, if you write Python code that in turn calls igv_notebook, you get an error: "Line 61: NameError: name 'get_ipython' is not defined." This modification explicitly imports get_ipython() so that it works regardless of whether or not igv_nbotebook is run from the top level namespace.