### PR TITLE
add requirements to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setuptools.setup(name='igv-notebook',
                  author='Jim Robinson',
                  url='https://github.com/igvteam/igv-notebook',
                  keywords=['igv', 'bioinformatics', 'genomics', 'visualization', 'ipython', 'jupyter'],
+                 install_requires=['ipykernel', 'ipython', 'requests'],
                  classifiers=[
                      'Development Status :: 4 - Beta',
                      'Intended Audience :: Science/Research',


### PR DESCRIPTION
Closes #16. I opted to add `ipykernel` and `ipython` as well as `requests`, as the package wouldn't work without them.

It's reasonable to assume that any normal user would have the first two packages installed already. But just in case they forget, this ensures that `pip` will take care of it. Also, it makes the dependency relationship clear to tools that inspect such things.